### PR TITLE
feat: add reusable EC2 instance module and minikube

### DIFF
--- a/modules/ec2-instance/README.md
+++ b/modules/ec2-instance/README.md
@@ -1,0 +1,145 @@
+# EC2 Instance Module
+
+A reusable Terraform module for creating EC2 instances with customizable security groups, AMI selection, and networking configuration.
+
+## Features
+
+- **Flexible AMI Selection**: Use specific AMI ID or automatic lookup with filters
+- **Customizable Security Groups**: Define ingress/egress rules as needed
+- **Configurable Networking**: Public/private IP, subnet placement
+- **Optional SSH Key**: Attach SSH key pairs for access
+- **User Data Support**: Run initialization scripts on launch
+- **Block Device Configuration**: Customize root volume size and type
+- **Detailed Monitoring**: Optional CloudWatch detailed monitoring
+- **Tagging Support**: Apply custom tags to all resources
+
+## Usage
+
+### Basic Example
+
+```hcl
+module "web_server" {
+  source = "./modules/ec2-instance"
+
+  name_prefix   = "my-web-server"
+  subnet_ids    = ["subnet-abc123"]
+  vpc_id        = "vpc-xyz789"
+  instance_type = "t3.small"
+
+  security_group_ingress_rules = [
+    {
+      description = "HTTP"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    },
+    {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["10.0.0.0/16"]
+    }
+  ]
+
+  tags = {
+    Environment = "production"
+    Application = "web"
+  }
+}
+```
+
+### With Specific AMI
+
+```hcl
+module "instance" {
+  source = "./modules/ec2-instance"
+
+  name_prefix = "custom-ami-instance"
+  subnet_ids  = module.vpc.public_subnet_ids
+  vpc_id      = module.vpc.vpc_id
+  ami_id      = "ami-0c55b159cbfafe1f0"
+
+  security_group_ingress_rules = [
+    {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
+}
+```
+
+### With User Data
+
+```hcl
+module "instance" {
+  source = "./modules/ec2-instance"
+
+  name_prefix   = "bootstrapped-instance"
+  subnet_ids    = module.vpc.public_subnet_ids
+  vpc_id        = module.vpc.vpc_id
+  instance_type = "t3.micro"
+
+  user_data = <<-EOF
+    #!/bin/bash
+    apt-get update
+    apt-get install -y nginx
+    systemctl start nginx
+  EOF
+
+  security_group_ingress_rules = [
+    {
+      description = "HTTP"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name_prefix` | Prefix for resource names | `string` | n/a | yes |
+| `subnet_ids` | List of subnet IDs (first will be used) | `list(string)` | n/a | yes |
+| `vpc_id` | VPC ID for security group | `string` | n/a | yes |
+| `instance_type` | EC2 instance type | `string` | `"t3.micro"` | no |
+| `ami_id` | Specific AMI ID (overrides filter) | `string` | `null` | no |
+| `ami_name_filter` | AMI name filter pattern | `string` | `"ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"` | no |
+| `ami_owner` | AMI owner ID | `string` | `"099720109477"` | no |
+| `security_group_ingress_rules` | List of ingress rules | `list(object)` | `[]` | no |
+| `security_group_egress_rules` | List of egress rules | `list(object)` | Allow all | no |
+| `key_name` | SSH key pair name | `string` | `null` | no |
+| `user_data` | User data script | `string` | `null` | no |
+| `associate_public_ip_address` | Associate public IP | `bool` | `true` | no |
+| `root_block_device_volume_size` | Root volume size (GB) | `number` | `32` | no |
+| `root_block_device_volume_type` | Root volume type | `string` | `"gp3"` | no |
+| `enable_monitoring` | Enable detailed monitoring | `bool` | `false` | no |
+| `tags` | Additional tags | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `instance_id` | EC2 instance ID |
+| `public_ip` | Public IP address |
+| `private_ip` | Private IP address |
+| `public_dns` | Public DNS name |
+| `private_dns` | Private DNS name |
+| `security_group_id` | Security group ID |
+| `ami_id` | AMI ID used |
+
+## Notes
+
+- The module places the instance in the first subnet from `subnet_ids`
+- Default egress rule allows all outbound traffic
+- Default AMI is Ubuntu 22.04 LTS from Canonical
+- Security group is created and managed by the module
+- For production use, restrict security group rules to specific CIDRs

--- a/modules/ec2-instance/main.tf
+++ b/modules/ec2-instance/main.tf
@@ -1,0 +1,81 @@
+data "aws_ami" "selected" {
+  count       = var.ami_id == null ? 1 : 0
+  most_recent = true
+  owners      = [var.ami_owner]
+
+  filter {
+    name   = "name"
+    values = [var.ami_name_filter]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+locals {
+  ami_id = var.ami_id != null ? var.ami_id : data.aws_ami.selected[0].id
+}
+
+resource "aws_security_group" "this" {
+  name_prefix = "${var.name_prefix}-sg-"
+  description = "Security group for ${var.name_prefix}"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress_rules
+    content {
+      description = try(ingress.value.description, null)
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress_rules
+    content {
+      description = try(egress.value.description, null)
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-sg"
+    }
+  )
+}
+
+resource "aws_instance" "this" {
+  ami                         = local.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = element(var.subnet_ids, 0)
+  vpc_security_group_ids      = [aws_security_group.this.id]
+  key_name                    = var.key_name
+  user_data                   = var.user_data
+  associate_public_ip_address = var.associate_public_ip_address
+  monitoring                  = var.enable_monitoring
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+    volume_type = var.root_block_device_volume_type
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = var.name_prefix
+    }
+  )
+}

--- a/modules/ec2-instance/outputs.tf
+++ b/modules/ec2-instance/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.this.id
+}
+
+output "public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.this.public_ip
+}
+
+output "private_ip" {
+  description = "Private IP of the EC2 instance"
+  value       = aws_instance.this.private_ip
+}
+
+output "public_dns" {
+  description = "Public DNS name of the EC2 instance"
+  value       = aws_instance.this.public_dns
+}
+
+output "private_dns" {
+  description = "Private DNS name of the EC2 instance"
+  value       = aws_instance.this.private_dns
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = aws_security_group.this.id
+}
+
+output "ami_id" {
+  description = "AMI ID used for the instance"
+  value       = local.ami_id
+}

--- a/modules/ec2-instance/variables.tf
+++ b/modules/ec2-instance/variables.tf
@@ -1,0 +1,117 @@
+variable "subnet_ids" {
+  description = "List of subnet IDs where the EC2 instance may be placed. The first subnet will be used."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "At least one subnet ID must be provided."
+  }
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the security group will be created"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "name_prefix" {
+  description = "Prefix used for naming resources"
+  type        = string
+}
+
+variable "ami_name_filter" {
+  description = "AMI name filter to select an AMI"
+  type        = string
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64*"
+}
+
+variable "ami_owner" {
+  description = "AMI owner ID"
+  type        = string
+  default     = "099720109477" # Canonical
+}
+
+variable "ami_id" {
+  description = "Specific AMI ID to use (overrides ami_name_filter and ami_owner)"
+  type        = string
+  default     = null
+}
+
+variable "security_group_ingress_rules" {
+  description = "List of ingress rules for the security group"
+  type = list(object({
+    description = optional(string)
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+  }))
+  default = []
+}
+
+variable "security_group_egress_rules" {
+  description = "List of egress rules for the security group"
+  type = list(object({
+    description = optional(string)
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+  }))
+  default = [
+    {
+      description = "Allow all outbound traffic"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
+}
+
+variable "key_name" {
+  description = "Name of the SSH key pair to attach to the instance"
+  type        = string
+  default     = null
+}
+
+variable "user_data" {
+  description = "User data script to run on instance launch"
+  type        = string
+  default     = null
+}
+
+variable "associate_public_ip_address" {
+  description = "Whether to associate a public IP address"
+  type        = bool
+  default     = true
+}
+
+variable "root_block_device_volume_size" {
+  description = "Size of the root block device in GB"
+  type        = number
+  default     = 32
+}
+
+variable "root_block_device_volume_type" {
+  description = "Type of root block device (gp2, gp3, io1, etc.)"
+  type        = string
+  default     = "gp3"
+}
+
+variable "enable_monitoring" {
+  description = "Enable detailed monitoring"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/ssh-key-pair/README.md
+++ b/modules/ssh-key-pair/README.md
@@ -1,0 +1,65 @@
+# SSH Key Pair Module
+
+A simple Terraform module for creating AWS EC2 key pairs from SSH public keys.
+
+## Features
+
+- Creates AWS EC2 key pair from SSH public key material
+- Supports custom tagging
+- Outputs key name, ID, and fingerprint
+
+## Usage
+
+### Basic Example
+
+```hcl
+module "ssh_key" {
+  source = "./modules/ssh-key-pair"
+
+  key_name   = "my-ssh-key"
+  public_key = file("~/.ssh/id_rsa.pub")
+
+  tags = {
+    Environment = "production"
+    Owner       = "ops-team"
+  }
+}
+```
+
+### With Inline Public Key
+
+```hcl
+module "ssh_key" {
+  source = "./modules/ssh-key-pair"
+
+  key_name   = "deployment-key"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..."
+
+  tags = {
+    Purpose = "CI/CD Deployments"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `key_name` | Name of the SSH key pair | `string` | n/a | yes |
+| `public_key` | SSH public key material | `string` | n/a | yes |
+| `tags` | Additional tags for the key pair | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `key_name` | Name of the SSH key pair |
+| `key_pair_id` | ID of the SSH key pair |
+| `fingerprint` | Fingerprint of the SSH key pair |
+
+## Notes
+
+- The key pair name must be unique within the AWS region
+- Public key must be in OpenSSH format
+- Maximum key pair name length is 255 characters
+- AWS supports RSA, ED25519, and ECDSA keys

--- a/modules/ssh-key-pair/main.tf
+++ b/modules/ssh-key-pair/main.tf
@@ -1,0 +1,6 @@
+resource "aws_key_pair" "this" {
+  key_name   = var.key_name
+  public_key = var.public_key
+
+  tags = var.tags
+}

--- a/modules/ssh-key-pair/outputs.tf
+++ b/modules/ssh-key-pair/outputs.tf
@@ -1,0 +1,14 @@
+output "key_name" {
+  description = "Name of the SSH key pair"
+  value       = aws_key_pair.this.key_name
+}
+
+output "key_pair_id" {
+  description = "ID of the SSH key pair"
+  value       = aws_key_pair.this.id
+}
+
+output "fingerprint" {
+  description = "Fingerprint of the SSH key pair"
+  value       = aws_key_pair.this.fingerprint
+}

--- a/modules/ssh-key-pair/variables.tf
+++ b/modules/ssh-key-pair/variables.tf
@@ -1,0 +1,15 @@
+variable "key_name" {
+  description = "Name of the SSH key pair"
+  type        = string
+}
+
+variable "public_key" {
+  description = "SSH public key material"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the key pair"
+  type        = map(string)
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -141,3 +141,34 @@ output "backend_config" {
   value       = var.enable_remote_state ? module.terraform_backend[0].backend_config : null
   sensitive   = false
 }
+
+# Minikube Instance Outputs
+output "minikube_instance_id" {
+  description = "ID of the minikube EC2 instance"
+  value       = module.minikube.instance_id
+}
+
+output "minikube_public_ip" {
+  description = "Public IP address of the minikube instance"
+  value       = module.minikube.public_ip
+}
+
+output "minikube_private_ip" {
+  description = "Private IP address of the minikube instance"
+  value       = module.minikube.private_ip
+}
+
+output "minikube_public_dns" {
+  description = "Public DNS name of the minikube instance"
+  value       = module.minikube.public_dns
+}
+
+output "minikube_security_group_id" {
+  description = "Security group ID attached to the minikube instance"
+  value       = module.minikube.security_group_id
+}
+
+output "minikube_ssh_command" {
+  description = "SSH command to connect to the minikube instance"
+  value       = "ssh -i ~/.ssh/id_rsa ecoutu@${module.minikube.public_ip}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,22 @@ variable "github_variables" {
   type        = map(string)
   default     = {}
 }
+
+variable "minikube_instance_type" {
+  description = "Instance type to use for the minikube EC2 instance"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "List of CIDR blocks allowed to SSH to development instances (override to restrict access). Defaults to 0.0.0.0/0 to preserve existing behavior but should be tightened in production."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "allowed_k8s_api_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access Kubernetes API Server (override to restrict access). Defaults to 0.0.0.0/0 to preserve existing behavior but should be tightened in production."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+


### PR DESCRIPTION
## Description
This PR adds a reusable EC2 instance module and implements the minikube instance using it.

## Changes
- Created generic  module with configurable security groups, AMI selection, and instance settings
- Added minikube instance using the new module with SSH (port 22) and Kubernetes API (port 8443) access
- Module supports dynamic ingress rules, custom user data, and flexible networking configuration

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Terraform validate passes
- [x] Terraform fmt applied
- [ ] Tested in development environment
- [ ] Tested in production environment

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [ ] Tests added/updated
- [x] Dependent changes merged

## Related Issues
Closes #12