### PR TITLE
feat: Add Route53 hosted zones for linklayer.ca domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -259,3 +259,35 @@ module "github_secrets" {
     }
   )
 }
+
+# Route53 Hosted Zones for linklayer.ca
+module "route53" {
+  source = "./modules/route53"
+
+  domain_name         = var.domain_name
+  create_public_zone  = true
+  create_private_zone = true
+  vpc_id              = module.vpc.vpc_id
+
+  dns_records = {
+    minikube_public = {
+      name    = "minikube.${var.domain_name}"
+      type    = "A"
+      ttl     = 300
+      records = [module.minikube.public_ip]
+      zone    = "public"
+    }
+    minikube_private = {
+      name    = "minikube.${var.domain_name}"
+      type    = "A"
+      ttl     = 300
+      records = [module.minikube.private_ip]
+      zone    = "private"
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = var.project_name
+  }
+}

--- a/modules/route53/README.md
+++ b/modules/route53/README.md
@@ -1,0 +1,144 @@
+# Route53 Hosted Zones Module
+
+This module creates AWS Route53 hosted zones for DNS management.
+
+## Features
+
+- Public hosted zone for internet-accessible DNS records
+- Private hosted zone for internal VPC DNS resolution
+- Flexible configuration to create either or both zones
+- Comprehensive outputs for zone IDs and name servers
+
+## Usage
+
+```hcl
+module "route53" {
+  source = "./modules/route53"
+
+  domain_name         = "example.com"
+  create_public_zone  = true
+  create_private_zone = true
+  vpc_id              = module.vpc.vpc_id
+
+  tags = {
+    Environment = "production"
+    ManagedBy   = "Terraform"
+  }
+}
+```
+
+## Examples
+
+### Public Zone Only
+```hcl
+module "route53_public" {
+  source = "./modules/route53"
+
+  domain_name        = "example.com"
+  create_public_zone = true
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+### Private Zone Only
+```hcl
+module "route53_private" {
+  source = "./modules/route53"
+
+  domain_name          = "internal.example.com"
+  create_public_zone   = false
+  create_private_zone  = true
+  vpc_id               = "vpc-123456"
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+### Both Public and Private Zones
+```hcl
+module "route53" {
+  source = "./modules/route53"
+
+  domain_name         = "example.com"
+  create_public_zone  = true
+  create_private_zone = true
+  vpc_id              = module.vpc.vpc_id
+
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| domain_name | The domain name for the hosted zone | string | - | yes |
+| create_public_zone | Create a public hosted zone | bool | true | no |
+| create_private_zone | Create a private hosted zone | bool | false | no |
+| vpc_id | VPC ID for private hosted zone | string | null | no* |
+| tags | Tags to apply to hosted zones | map(string) | {} | no |
+| dns_records | Map of DNS records to create | map(object) | {} | no |
+
+*Required if `create_private_zone` is `true`
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| public_zone_id | The hosted zone ID of the public zone |
+| public_name_servers | The name servers for the public hosted zone |
+| private_zone_id | The hosted zone ID of the private zone |
+| private_name_servers | The name servers for the private hosted zone |
+| domain_name | The domain name of the hosted zones |
+| public_record_fqdns | Map of public DNS record FQDNs |
+| private_record_fqdns | Map of private DNS record FQDNs |
+
+## Notes
+
+### Public Zone
+- Creates a public hosted zone accessible from the internet
+- Returns name servers that need to be configured with your domain registrar
+- Supports standard DNS record types (A, AAAA, CNAME, MX, TXT, etc.)
+
+### Private Zone
+- Creates a private hosted zone associated with a VPC
+- Only accessible from within the associated VPC
+- Ideal for internal service discovery and private DNS resolution
+- Requires a VPC ID to be specified
+
+### DNS Delegation
+After creating a public hosted zone, you must:
+1. Note the name servers from `public_name_servers` output
+2. Update your domain registrar's name server configuration
+3. Wait for DNS propagation (typically 24-48 hours)
+
+## Example DNS Records
+
+After creating the zones, you can add DNS records:
+
+```hcl
+# Public A record
+resource "aws_route53_record" "www" {
+  zone_id = module.route53.public_zone_id
+  name    = "www.example.com"
+  type    = "A"
+  ttl     = 300
+  records = ["203.0.113.1"]
+}
+
+# Private A record
+resource "aws_route53_record" "internal" {
+  zone_id = module.route53.private_zone_id
+  name    = "db.internal.example.com"
+  type    = "A"
+  ttl     = 300
+  records = ["10.0.1.100"]
+}
+```

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -1,0 +1,52 @@
+resource "aws_route53_zone" "public" {
+  count = var.create_public_zone ? 1 : 0
+
+  name = var.domain_name
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.domain_name}-public"
+      Type = "Public"
+    }
+  )
+}
+
+resource "aws_route53_zone" "private" {
+  count = var.create_private_zone ? 1 : 0
+
+  name = var.domain_name
+
+  vpc {
+    vpc_id = var.vpc_id
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.domain_name}-private"
+      Type = "Private"
+    }
+  )
+}
+
+# DNS Records
+resource "aws_route53_record" "public" {
+  for_each = { for k, v in var.dns_records : k => v if v.zone == "public" && var.create_public_zone }
+
+  zone_id = aws_route53_zone.public[0].zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = each.value.ttl
+  records = each.value.records
+}
+
+resource "aws_route53_record" "private" {
+  for_each = { for k, v in var.dns_records : k => v if v.zone == "private" && var.create_private_zone }
+
+  zone_id = aws_route53_zone.private[0].zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = each.value.ttl
+  records = each.value.records
+}

--- a/modules/route53/outputs.tf
+++ b/modules/route53/outputs.tf
@@ -1,0 +1,34 @@
+output "public_zone_id" {
+  description = "The hosted zone ID of the public zone"
+  value       = var.create_public_zone ? aws_route53_zone.public[0].zone_id : null
+}
+
+output "public_name_servers" {
+  description = "The name servers for the public hosted zone"
+  value       = var.create_public_zone ? aws_route53_zone.public[0].name_servers : []
+}
+
+output "private_zone_id" {
+  description = "The hosted zone ID of the private zone"
+  value       = var.create_private_zone ? aws_route53_zone.private[0].zone_id : null
+}
+
+output "private_name_servers" {
+  description = "The name servers for the private hosted zone (for internal AWS use only; private zones use VPC DNS resolution)"
+  value       = var.create_private_zone ? aws_route53_zone.private[0].name_servers : []
+}
+
+output "domain_name" {
+  description = "The domain name of the hosted zones"
+  value       = var.domain_name
+}
+
+output "public_record_fqdns" {
+  description = "Map of public DNS record FQDNs"
+  value       = { for k, v in aws_route53_record.public : k => v.fqdn }
+}
+
+output "private_record_fqdns" {
+  description = "Map of private DNS record FQDNs"
+  value       = { for k, v in aws_route53_record.private : k => v.fqdn }
+}

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -1,0 +1,45 @@
+variable "domain_name" {
+  description = "The domain name for the hosted zone"
+  type        = string
+}
+
+variable "create_public_zone" {
+  description = "Create a public hosted zone"
+  type        = bool
+  default     = true
+}
+
+variable "create_private_zone" {
+  description = "Create a private hosted zone"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID for private hosted zone (required if create_private_zone is true)"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.create_private_zone || var.vpc_id != null
+    error_message = "vpc_id must be provided when create_private_zone is true."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to hosted zones"
+  type        = map(string)
+  default     = {}
+}
+
+variable "dns_records" {
+  description = "Map of DNS records to create"
+  type = map(object({
+    name    = string
+    type    = string
+    ttl     = number
+    records = list(string)
+    zone    = string # "public" or "private"
+  }))
+  default = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -172,3 +172,44 @@ output "minikube_ssh_command" {
   description = "SSH command to connect to the minikube instance"
   value       = "ssh -i ~/.ssh/id_rsa ecoutu@${module.minikube.public_ip}"
 }
+
+# Route53 Outputs
+output "route53_public_zone_id" {
+  description = "The hosted zone ID of the public Route53 zone"
+  value       = module.route53.public_zone_id
+}
+
+output "route53_public_name_servers" {
+  description = "The name servers for the public hosted zone (configure these with your domain registrar)"
+  value       = module.route53.public_name_servers
+}
+
+output "route53_private_zone_id" {
+  description = "The hosted zone ID of the private Route53 zone"
+  value       = module.route53.private_zone_id
+}
+
+output "route53_domain_name" {
+  description = "The domain name of the Route53 hosted zones"
+  value       = module.route53.domain_name
+}
+
+output "route53_public_record_fqdns" {
+  description = "Map of public DNS record FQDNs"
+  value       = module.route53.public_record_fqdns
+}
+
+output "route53_private_record_fqdns" {
+  description = "Map of private DNS record FQDNs"
+  value       = module.route53.private_record_fqdns
+}
+
+output "minikube_public_fqdn" {
+  description = "The public fully qualified domain name for the minikube instance"
+  value       = module.route53.public_record_fqdns["minikube_public"]
+}
+
+output "minikube_private_fqdn" {
+  description = "The private fully qualified domain name for the minikube instance"
+  value       = module.route53.private_record_fqdns["minikube_private"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -107,3 +107,9 @@ variable "allowed_k8s_api_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "domain_name" {
+  description = "Domain name for Route53 hosted zones"
+  type        = string
+  default     = "linklayer.ca"
+}
+


### PR DESCRIPTION
## Overview
Implements Route53 hosted zones for the linklayer.ca domain with both public and private zone support.

## Changes
- ✅ Created  module with public and private zone support
- ✅ Added public hosted zone for internet-accessible DNS records
- ✅ Added private hosted zone associated with VPC for internal DNS resolution
- ✅ Added  variable (default: linklayer.ca)
- ✅ Added Route53 outputs for zone IDs and name servers
- ✅ Updated  with domain configuration

## Module Features
- Flexible configuration to create either or both zone types
- Public zone for external DNS delegation
- Private zone for internal VPC service discovery
- Comprehensive documentation with usage examples

## Testing
- ✅ Terraform validation passed
- ✅ Terraform plan successful
- Module structure follows project conventions

## Post-Merge Actions
After applying this configuration:
1. Note the name servers from  output
2. Configure these name servers with your domain registrar
3. Wait for DNS propagation (24-48 hours)

Closes #14