### PR TITLE
Rename repository to kubernetes-stack and update documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Question or Discussion
-    url: https://github.com/ecoutu/terraform-stack/discussions
+    url: https://github.com/ecoutu/kubernetes-stack/discussions
     about: Ask questions or discuss ideas in GitHub Discussions

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,7 +24,7 @@ env:
   TF_VERSION: 1.13.5
   PKG_VERSION: 1.14.3
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/terraform-stack
+  IMAGE_NAME: ${{ github.repository }}/kubernetes-stack
 
 jobs:
   validate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! This document provides guidelines f
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/your-username/terraform-stack.git`
+2. Clone your fork: `git clone https://github.com/your-username/kubernetes-stack.git`
 3. Create a feature branch: `git checkout -b feature/your-feature-name`
 4. Make your changes
 5. Test your changes locally

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -340,7 +340,7 @@ Clear the plugin cache if you encounter issues:
 
 ```bash
 docker compose down -v
-docker volume rm terraform-stack_terraform-plugins
+docker volume rm kubernetes-stack_terraform-plugins
 make docker-build
 ```
 

--- a/GITHUB-SECRETS-SETUP.md
+++ b/GITHUB-SECRETS-SETUP.md
@@ -16,7 +16,7 @@ Automatically sets these in your GitHub repository:
 1. Visit: https://github.com/settings/tokens?type=beta
 2. Click "Generate new token" (fine-grained)
 3. Configure:
-   - **Repository**: Select `ecoutu/terraform-stack`
+   - **Repository**: Select `ecoutu/kubernetes-stack`
    - **Permissions**:
      - Secrets: Read and write ✅
      - Variables: Read and write ✅
@@ -44,10 +44,10 @@ This will:
 
 ```bash
 # Check secrets were created
-gh secret list -R ecoutu/terraform-stack
+gh secret list -R ecoutu/kubernetes-stack
 
 # Check variables were created
-gh variable list -R ecoutu/terraform-stack
+gh variable list -R ecoutu/kubernetes-stack
 
 # View Terraform outputs
 cd terraform && terraform output github_secrets_configured
@@ -87,7 +87,7 @@ terraform output github_actions_role_arn
 # 2. Manually set in GitHub
 gh secret set AWS_ROLE_TO_ASSUME \
      --body "$(cd terraform && terraform output -raw github_actions_role_arn)" \
-  --repo ecoutu/terraform-stack
+  --repo ecoutu/kubernetes-stack
 ```
 
 ## Verification
@@ -126,8 +126,9 @@ Terraform will automatically update the secret in GitHub.
 ## Troubleshooting
 
 ### "404 Not Found"
-- Verify repository name: `ecoutu/terraform-stack`
-- Check token has access to the repository
+- Verify repository name: `ecoutu/kubernetes-stack`
+# Check token has access to the repository
+
 
 ### "403 Forbidden"
 - Token needs "Secrets: Read and write" permission

--- a/OIDC-SETUP.md
+++ b/OIDC-SETUP.md
@@ -20,7 +20,7 @@ This creates:
 
 - GitHub OIDC provider in AWS
 - IAM role with Terraform permissions
-- Trust policy restricting to `ecoutu/terraform-stack` from `main`/`develop` branches
+- Trust policy restricting to `ecoutu/kubernetes-stack` from `main`/`develop` branches
 
 ### Step 2: Add GitHub Secret
 
@@ -37,12 +37,12 @@ Add to GitHub (choose one method):
 ```bash
 gh secret set AWS_ROLE_TO_ASSUME \
      --body "$(cd terraform && terraform output -raw github_actions_role_arn)" \
-  --repo ecoutu/terraform-stack
+  --repo ecoutu/kubernetes-stack
 ```
 
 **Method B - Web UI:**
 
-1. Go to: https://github.com/ecoutu/terraform-stack/settings/secrets/actions
+1. Go to: https://github.com/ecoutu/kubernetes-stack/settings/secrets/actions
 2. Click "New repository secret"
 3. Name: `AWS_ROLE_TO_ASSUME`
 4. Value: (paste the ARN)
@@ -58,7 +58,7 @@ git commit -m "Add OIDC authentication workflow"
 git push origin main
 ```
 
-Watch it run: https://github.com/ecoutu/terraform-stack/actions
+Watch it run: https://github.com/ecoutu/kubernetes-stack/actions
 
 ## How to Use in Your Workflows
 
@@ -112,7 +112,7 @@ cd terraform && terraform output
 **Error: "Not authorized to perform: sts:AssumeRoleWithWebIdentity"**
 
 - Ensure you're running from `main` or `develop` branch
-- Check repository name matches exactly: `ecoutu/terraform-stack`
+- Check repository name matches exactly: `ecoutu/kubernetes-stack`
 
 **Error: "Missing required permissions"**
 
@@ -121,7 +121,7 @@ cd terraform && terraform output
 
 **Secret not found**
 
-- Verify secret exists: `gh secret list -R ecoutu/terraform-stack`
+- Verify secret exists: `gh secret list -R ecoutu/kubernetes-stack`
 - Re-add using Step 2 above
 
 ## Next Steps
@@ -137,7 +137,7 @@ Customize in `terraform.tfvars`:
 
 ```hcl
 github_org      = "ecoutu"              # Your GitHub org
-github_repo     = "terraform-stack"     # Your repository name
+github_repo     = "kubernetes-stack"     # Your repository name
 github_branches = ["main", "develop"]   # Allowed branches
 ```
 

--- a/QUICK-REFERENCE.md
+++ b/QUICK-REFERENCE.md
@@ -59,7 +59,7 @@ make docker-clean                 # Remove all Docker resources
 ## File Structure
 
 ```
-terraform-stack/
+kubernetes-stack/
 ├── terraform/                    # Terraform configuration directory
 │   ├── main.tf                   # Root Terraform config
 │   ├── variables.tf              # Input variables

--- a/STATE-MIGRATION.md
+++ b/STATE-MIGRATION.md
@@ -232,7 +232,7 @@ For team environments, configure remote state:
 terraform {
   backend "s3" {
     bucket         = "my-terraform-state"
-    key            = "terraform-stack/terraform.tfstate"
+    key            = "kubernetes-stack/terraform.tfstate"
     region         = "us-east-1"
     encrypt        = true
     dynamodb_table = "terraform-locks"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: terraform-stack
+    container_name: kubernetes-stack
     working_dir: /workspace/terraform
     volumes:
       # Mount current directory
@@ -31,7 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: terraform-stack-dev
+    container_name: kubernetes-stack-dev
     working_dir: /workspace/terraform
     volumes:
       - .:/workspace

--- a/migrations/MIGRATION-SYSTEM.md
+++ b/migrations/MIGRATION-SYSTEM.md
@@ -25,7 +25,7 @@ The Terraform state migration system has been moved from a single bash script to
 ## New Directory Structure
 
 ```
-terraform-stack/
+kubernetes-stack/
 ├── migrations/              # New migration system
 │   ├── main.go             # Migration tool implementation
 │   ├── go.mod              # Go dependencies

--- a/migrations/go.mod
+++ b/migrations/go.mod
@@ -1,3 +1,3 @@
-module github.com/ecoutu/terraform-stack/migrations
+module github.com/ecoutu/kubernetes-stack/migrations
 
 go 1.21

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket       = "ecoutu-terraform-stack-state"
+    bucket       = "ecoutu-kubernetes-stack-state"
     key          = "terraform.tfstate"
     region       = "us-east-1"
     use_lockfile = true

--- a/terraform/modules/github-oidc-role/README.md
+++ b/terraform/modules/github-oidc-role/README.md
@@ -11,7 +11,7 @@ This module creates an AWS IAM role that allows GitHub Actions to authenticate u
    - Configured with GitHub's thumbprints
 
 2. **IAM Role**: `GitHubActionsTerraformRole`
-   - Can only be assumed by workflows from `ecoutu/terraform-stack`
+   - Can only be assumed by workflows from `ecoutu/kubernetes-stack`
    - Restricted to `main` and `develop` branches
    - Includes permissions for Terraform operations (S3, DynamoDB, EC2, VPC, IAM, etc.)
    - Session duration: 1 hour
@@ -27,7 +27,7 @@ This module creates an AWS IAM role that allows GitHub Actions to authenticate u
 ### Step 1: Deploy the Infrastructure
 
 ```bash
-cd /home/ecoutu/ecoutu/src/terraform-stack
+cd /home/ecoutu/ecoutu/src/kubernetes-stack
 terraform init
 terraform apply
 ```
@@ -42,7 +42,7 @@ terraform output github_actions_role_arn
 
 Add it as a repository secret:
 
-1. Go to: https://github.com/ecoutu/terraform-stack/settings/secrets/actions
+1. Go to: https://github.com/ecoutu/kubernetes-stack/settings/secrets/actions
 2. Click "New repository secret"
 3. Name: `AWS_ROLE_TO_ASSUME`
 4. Value: (paste the role ARN from above)
@@ -53,7 +53,7 @@ Or use GitHub CLI:
 ```bash
 gh secret set AWS_ROLE_TO_ASSUME \
   --body "$(terraform output -raw github_actions_role_arn)" \
-  --repo ecoutu/terraform-stack
+  --repo ecoutu/kubernetes-stack
 ```
 
 ### Step 3: Use in GitHub Actions
@@ -79,7 +79,7 @@ steps:
 3. **Workflow** presents the token to AWS STS
 4. **AWS** validates the token against the OIDC provider
 5. **AWS** checks the trust policy conditions:
-   - ✅ Repository matches: `ecoutu/terraform-stack`
+   - ✅ Repository matches: `ecoutu/kubernetes-stack`
    - ✅ Branch is `main` or `develop`
 6. **AWS** issues temporary credentials (valid for 1 hour)
 7. **Workflow** uses credentials to run Terraform
@@ -101,7 +101,7 @@ Test the authentication:
 git push origin main
 
 # Watch it run
-# Visit: https://github.com/ecoutu/terraform-stack/actions
+# Visit: https://github.com/ecoutu/kubernetes-stack/actions
 
 # Check CloudTrail for OIDC events
 aws cloudtrail lookup-events \

--- a/terraform/modules/github-secrets/README.md
+++ b/terraform/modules/github-secrets/README.md
@@ -19,7 +19,7 @@ module "github_secrets" {
   source = "./modules/github-secrets"
 
   github_token    = var.github_token
-  repository_name = "ecoutu/terraform-stack"
+  repository_name = "ecoutu/kubernetes-stack"
   aws_role_arn    = module.github_actions_role.role_arn
   aws_region      = "us-east-1"
 }
@@ -32,7 +32,7 @@ module "github_secrets" {
   source = "./modules/github-secrets"
 
   github_token    = var.github_token
-  repository_name = "ecoutu/terraform-stack"
+  repository_name = "ecoutu/kubernetes-stack"
   aws_role_arn    = module.github_actions_role.role_arn
   aws_region      = "us-east-1"
 
@@ -144,7 +144,7 @@ module "github_actions_role" {
 
   role_name       = "GitHubActionsTerraformRole"
   github_org      = "ecoutu"
-  github_repo     = "terraform-stack"
+  github_repo     = "kubernetes-stack"
   github_branches = ["main", "develop"]
 
   inline_policies = {
@@ -164,7 +164,7 @@ module "github_secrets" {
   source = "./modules/github-secrets"
 
   github_token    = var.github_token
-  repository_name = "ecoutu/terraform-stack"
+  repository_name = "ecoutu/kubernetes-stack"
   aws_role_arn    = module.github_actions_role.role_arn
   aws_region      = var.aws_region
 }
@@ -176,21 +176,21 @@ After applying, verify the secrets were created:
 
 ```bash
 # Using GitHub CLI
-gh secret list -R ecoutu/terraform-stack
+gh secret list -R ecoutu/kubernetes-stack
 
 # Expected output:
 # AWS_ROLE_TO_ASSUME  Updated YYYY-MM-DD
 
 # Check variables
-gh variable list -R ecoutu/terraform-stack
+gh variable list -R ecoutu/kubernetes-stack
 
 # Expected output:
 # AWS_REGION  us-east-1  Updated YYYY-MM-DD
 ```
 
 Or check in the GitHub UI:
-- Secrets: https://github.com/ecoutu/terraform-stack/settings/secrets/actions
-- Variables: https://github.com/ecoutu/terraform-stack/settings/variables/actions
+- Secrets: https://github.com/ecoutu/kubernetes-stack/settings/secrets/actions
+- Variables: https://github.com/ecoutu/kubernetes-stack/settings/variables/actions
 
 ## Workflow Usage
 
@@ -327,7 +327,7 @@ To remove secrets managed by this module:
 terraform apply
 
 # Or manually delete
-gh secret delete AWS_ROLE_TO_ASSUME -R ecoutu/terraform-stack
+gh secret delete AWS_ROLE_TO_ASSUME -R ecoutu/kubernetes-stack
 ```
 
 ## Advanced Usage
@@ -342,7 +342,7 @@ module "github_secrets" {
   count  = var.github_token != "" ? 1 : 0
 
   github_token    = var.github_token
-  repository_name = "ecoutu/terraform-stack"
+  repository_name = "ecoutu/kubernetes-stack"
   aws_role_arn    = module.github_actions_role.role_arn
   aws_region      = var.aws_region
 }
@@ -375,7 +375,7 @@ module "github_secrets_terraform" {
   source = "./modules/github-secrets"
 
   github_token    = var.github_token
-  repository_name = "ecoutu/terraform-stack"
+  repository_name = "ecoutu/kubernetes-stack"
   aws_role_arn    = module.github_actions_terraform_role.role_arn
   aws_region      = "us-east-1"
 }

--- a/terraform/modules/terraform-backend/README.md
+++ b/terraform/modules/terraform-backend/README.md
@@ -73,7 +73,7 @@ Terraform will ask to migrate your local state to S3. Type `yes` to confirm.
 ```bash
 # 1. Enable remote state in terraform.tfvars
 enable_remote_state = true
-terraform_state_bucket = "ecoutu-terraform-stack-state"
+terraform_state_bucket = "ecoutu-kubernetes-stack-state"
 
 # 2. Apply to create S3 and DynamoDB resources
 terraform init
@@ -97,10 +97,10 @@ terraform {
   required_version = ">= 1.0"
 
   backend "s3" {
-    bucket         = "ecoutu-terraform-stack-state"
+    bucket         = "ecoutu-kubernetes-stack-state"
     key            = "terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "ecoutu-terraform-stack-state-lock"
+    dynamodb_table = "ecoutu-kubernetes-stack-lock"
     encrypt        = true
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,7 +46,7 @@ variable "github_org" {
 variable "github_repo" {
   description = "GitHub repository name"
   type        = string
-  default     = "terraform-stack"
+  default     = "kubernetes-stack"
 }
 
 variable "github_branches" {


### PR DESCRIPTION
This PR addresses #32 by renaming the repository and updating all relevant documentation, workflows, and configuration references from 'terraform-stack' to 'kubernetes-stack' or 'media-stack' as appropriate.\n\n- Updates README and documentation\n- Updates GitHub Actions and workflow files\n- Updates Terraform and Helm references\n- See commit for full file list\n\nFixes #32.